### PR TITLE
fix: typo

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -60,7 +60,8 @@ export function useLocalState<T, E extends ResourceExtra>(
     dataRef.current = data;
     setValue(data);
   }
-  return [value, { ...extra, setData: setValue }] as const;
+  const newExtra = useMemo(() => ({ ...extra, setData: setValue }), [extra]);
+  return [value, newExtra] as const;
 }
 
 export function useDefault<T, E extends ResourceExtra>(
@@ -128,7 +129,7 @@ export function createResourceHook<Args extends unknown[], T>(
               promise: result,
               abort: noop,
             };
-      // The rejected promise will alaways be handled later (in the next useEffect)
+      // The rejected promise will always be handled later (in the next useEffect)
       // handle it immediately to prevent unhandled Promise rejection warning
       requestResult.promise.catch(() => {});
       setRequestResult(requestResult);
@@ -151,7 +152,14 @@ export function createResourceHook<Args extends unknown[], T>(
       };
     }, [promise]);
 
-    return [data, { error, loading, reload, abort }];
+    const extra = useMemo(() => ({ error, loading, reload, abort }), [
+      error,
+      loading,
+      reload,
+      abort,
+    ]);
+
+    return [data, extra];
   };
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -128,7 +128,7 @@ export function createResourceHook<Args extends unknown[], T>(
               promise: result,
               abort: noop,
             };
-      // The rejected promise will alaways be handled later (in the next useEffect)
+      // The rejected promise will always be handled later (in the next useEffect)
       // handle it immediately to prevent unhandled Promise rejection warning
       requestResult.promise.catch(() => {});
       setRequestResult(requestResult);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -60,8 +60,7 @@ export function useLocalState<T, E extends ResourceExtra>(
     dataRef.current = data;
     setValue(data);
   }
-  const newExtra = useMemo(() => ({ ...extra, setData: setValue }), [extra]);
-  return [value, newExtra] as const;
+  return [value, { ...extra, setData: setValue }] as const;
 }
 
 export function useDefault<T, E extends ResourceExtra>(
@@ -129,7 +128,7 @@ export function createResourceHook<Args extends unknown[], T>(
               promise: result,
               abort: noop,
             };
-      // The rejected promise will always be handled later (in the next useEffect)
+      // The rejected promise will alaways be handled later (in the next useEffect)
       // handle it immediately to prevent unhandled Promise rejection warning
       requestResult.promise.catch(() => {});
       setRequestResult(requestResult);
@@ -152,14 +151,7 @@ export function createResourceHook<Args extends unknown[], T>(
       };
     }, [promise]);
 
-    const extra = useMemo(() => ({ error, loading, reload, abort }), [
-      error,
-      loading,
-      reload,
-      abort,
-    ]);
-
-    return [data, extra];
+    return [data, { error, loading, reload, abort }];
   };
 }
 

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -117,23 +117,3 @@ test('Conditional', async () => {
     expect(error).toBe(undefined);
   })();
 });
-
-test('Treat ResourceExtra as a whole', async () => {
-  const { result, rerender, waitForNextUpdate } = renderHook(() =>
-    useSimpleEcho(['1'])
-  );
-  const extraSnapshot1 = result.current[1];
-
-  rerender();
-
-  expect(result.current[1]).toBe(extraSnapshot1);
-
-  await waitForNextUpdate();
-
-  const extraSnapshot2 = result.current[1];
-  expect(extraSnapshot1).not.toBe(extraSnapshot2);
-
-  rerender();
-
-  expect(result.current[1]).toBe(extraSnapshot2);
-});

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -117,3 +117,23 @@ test('Conditional', async () => {
     expect(error).toBe(undefined);
   })();
 });
+
+test('Treat ResourceExtra as a whole', async () => {
+  const { result, rerender, waitForNextUpdate } = renderHook(() =>
+    useSimpleEcho(['1'])
+  );
+  const extraSnapshot1 = result.current[1];
+
+  rerender();
+
+  expect(result.current[1]).toBe(extraSnapshot1);
+
+  await waitForNextUpdate();
+
+  const extraSnapshot2 = result.current[1];
+  expect(extraSnapshot1).not.toBe(extraSnapshot2);
+
+  rerender();
+
+  expect(result.current[1]).toBe(extraSnapshot2);
+});


### PR DESCRIPTION
<details>
<summary>之前的说明</summary>

### 一点私货

开发控制台时，这样使用 ResourceExtra 导致了死循环：
```ts
const reload = useCallback(() => {
  deployExtra.reload();
  domainExtra.reload();
}, [deployExtra, domainExtra]);
```

看完 useEngineAPI 的实现方式才知道每次 render 都会返回一个新的 extra ，不管其各个成员是否改变。但 useEngineAPI 返回一个元组，给人一种 ResourceExtra 是一个整体，在必要时才会改变的感觉。

在控制台的代码中看到过解构整个 extra 的用法，而且其他使用这个库的人也有可能这样使用，于是做了一点微小的工作：缓存整个 ResourceExtra ，在必要时才更改。上述写法将不会引起死循环。
</details>